### PR TITLE
Bugfix: Switch around user-group relationship so foaf:member is part of the user-group

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -125,7 +125,8 @@
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       SELECT ?account WHERE {
           <SESSION_ID> session:account ?account .
-          ?user foaf:account ?account ; foaf:member <http://data.rollvolet.be/user-groups/admin> .
+          ?user foaf:account ?account .
+          <http://data.rollvolet.be/user-groups/admin> foaf:member ?user .
       } LIMIT 1")
 
 (grant (read)

--- a/config/migrations/20241031103000-switch-relationship-user-groups.sparql
+++ b/config/migrations/20241031103000-switch-relationship-user-groups.sparql
@@ -1,0 +1,17 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+DELETE {
+  GRAPH ?g {
+    ?person foaf:member ?userGroup .
+  }
+} 
+INSERT {
+  GRAPH ?g {
+    ?userGroup foaf:member ?person .
+  }
+} 
+WHERE {
+  GRAPH ?g {
+    ?userGroup a foaf:Group .
+    ?person foaf:member ?userGroup .
+  }
+}

--- a/config/resources/users.json
+++ b/config/resources/users.json
@@ -30,7 +30,8 @@
         "user-groups": {
           "predicate": "foaf:member",
           "target": "user-group",
-          "cardinality": "many"
+          "cardinality": "many",
+          "inverse": true
         },
         "employee": {
           "predicate": "prov:alternateOf",
@@ -89,8 +90,7 @@
         "users": {
           "predicate": "foaf:member",
           "target": "user",
-          "cardinality": "many",
-          "inverse": true
+          "cardinality": "many"
         }
       },
       "features": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     labels:
       - "logging=true"
   msal-login:
-    image: rollvolet/msal-login-service:2.0.0
+    image: rollvolet/msal-login-service:3.0.0
     environment:
       AUTH_SCOPES: "User.Read Calendars.ReadWrite.Shared Files.ReadWrite.All"
       AUTH_REFRESH_TOKENS: "true"


### PR DESCRIPTION
initially a bug in msal-login-service. Switches around the relationship so `foaf:member` is part of a Group, instead of a Person.
